### PR TITLE
Improve filtering

### DIFF
--- a/tvoverlord/config.py
+++ b/tvoverlord/config.py
@@ -460,10 +460,19 @@ class Configuration:
         except configparser.NoOptionError:
             self.telemetry_ok = None
 
+        self.filter_list_bad = []
+        self.filter_list_good = []
         try:
             filter_list = cfg.get('App Settings', 'filters')
             self.filter_list = [
                 i.strip().lower() for i in filter_list.split(',') if i.strip()]
+            for f in self.filter_list:
+                if f.startswith("+"):
+                    self.filter_list_good.append(f[1:])
+                elif f.startswith("-"):
+                    self.filter_list_bad.append(f[1:])
+                else:
+                    self.filter_list_bad.append(f)
         except configparser.NoOptionError:
             self.filter_list = []
 

--- a/tvoverlord/search.py
+++ b/tvoverlord/search.py
@@ -203,11 +203,19 @@ class Search(object):
 
     def filter_episode(self, episode):
         bad = False
-        for f in Config.filter_list:
-            if f.lower() in episode[0].lower():
-                bad = True
-        if not bad:
-            return episode
+        good = False if Config.filter_list_good else True
+        if not good:
+            for f in Config.filter_list_good:
+                if f.lower() in episode[0].lower():
+                    good = True
+                    break
+        if good:
+            for f in Config.filter_list_bad:
+                if f.lower() in episode[0].lower():
+                    bad = True
+                    break
+            if not bad:
+                return episode
 
     def sort_torrents(self, episodes):
         # sort by seeds

--- a/tvoverlord/tvol.py
+++ b/tvoverlord/tvol.py
@@ -401,7 +401,7 @@ def list_missing(today):
 @click.option('--exclude', '-x',
               help='Comma seperated list of search engines to ignore.')
 @click.option('--filters', '-f',
-              help='Comma seperated list of strings to filter search results.  This will override config.ini.')
+              help='Comma seperated list of strings to filter search results.  Prepend strings that must appear in the filename with "+".  Prepend strings that shouldn\'t appear in the filename with "-".   This will override config.ini.')
 def download(show_name, today, ignore, count, exclude, filters):
     """Download available episodes.
 
@@ -422,8 +422,17 @@ def download(show_name, today, ignore, count, exclude, filters):
         Config.blacklist = list(set(Config.blacklist + blacklist))
 
     if filters:
+        Config.filter_list_bad = []
+        Config.filter_list_good = []
         Config.filter_list = [
             i.strip().lower() for i in filters.split(',') if i.strip()]
+        for f in Config.filter_list:
+            if f.startswith("+"):
+                Config.filter_list_good.append(f[1:])
+            elif f.startswith("-"):
+                Config.filter_list_bad.append(f[1:])
+            else:
+                Config.filter_list_bad.append(f)
 
     shows = Shows(name_filter=show_name)
     for show in shows:


### PR DESCRIPTION
"+filterword" -> only show results that contain the filterword
"-filterword" -> don't show results that contain the filterword
Filterwords without prefix default to current behavior and are not included in the search result.