### PR TITLE
Workaround bad json in rarbg search

### DIFF
--- a/tvoverlord/search_providers/rarbg_to.py
+++ b/tvoverlord/search_providers/rarbg_to.py
@@ -67,7 +67,10 @@ class Provider():
             except requests.exceptions.Timeout:
                 continue
 
-            results = r.json()
+            try:
+                results = r.json()
+            except:
+                continue
             if 'error_code' in results.keys() and results['error_code'] == 20:
                 continue  # no results found
 


### PR DESCRIPTION
Error traceback:

```pytb
Traceback (most recent call last):                                                                                                                                                                    
  File "/home/js/.local/share/miniconda3/bin/tvol", line 11, in <module>
    load_entry_point('tvoverlord', 'console_scripts', 'tvol')()
  File "/home/js/.local/share/miniconda3/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/js/.local/share/miniconda3/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/js/.local/share/miniconda3/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/js/.local/share/miniconda3/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/js/.local/share/miniconda3/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/js/external/tv-overlord/tvoverlord/tvol.py", line 438, in download
    show.download_missing(count, today)
  File "/home/js/external/tv-overlord/tvoverlord/show.py", line 228, in download_missing
    search_type=Config.search_type,
  File "/home/js/external/tv-overlord/tvoverlord/search.py", line 168, in search
    results = future.result()
  File "/home/js/.local/share/miniconda3/lib/python3.6/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/home/js/.local/share/miniconda3/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/js/.local/share/miniconda3/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/js/external/tv-overlord/tvoverlord/search.py", line 71, in job
    search_results = search.search(search_string, season, episode)
  File "/home/js/external/tv-overlord/tvoverlord/search_providers/rarbg_to.py", line 70, in search
    results = r.json()
  File "/home/js/.local/share/miniconda3/lib/python3.6/site-packages/requests/models.py", line 892, in json
    return complexjson.loads(self.text, **kwargs)
  File "/home/js/.local/share/miniconda3/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/home/js/.local/share/miniconda3/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/home/js/.local/share/miniconda3/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```